### PR TITLE
Support gfortran (and other modern FCs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ config.h.in
 config.h.in~
 config.log
 config.status
+config.guess
+config.sub
 configure
 install-sh
 missing

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,8 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 # Checks for programs
 AC_REVISION($Revision$)
 #AC_PROG_CC
-AC_PROG_F77
+AC_PROG_F77([f77 fort77 g77 f90 f95 fort g95 gfortran ifort])
+AC_F77_LIBRARY_LDFLAGS
 
 # Safety check
 AC_CONFIG_SRCDIR([src/proas.f])
@@ -31,7 +32,7 @@ esac
 # Checks for libraries
 AC_MSG_RESULT(LDFLAGS set to... $LDFLAGS)
 AC_CHECK_LIB([X11], main,,AC_MSG_ERROR(X11 library not found))
-AC_CHECK_LIB([pgplot], main,,AC_MSG_ERROR(pgplot library not found))
+AC_CHECK_LIB([pgplot], main,,AC_MSG_ERROR(pgplot library not found), [$FLIBS])
 # Define in LIBS all the previous libraries
 LIBS="$LIBS"
 


### PR DESCRIPTION
At first it cannot find gfortran.

Then when I ./configure F77=gfortran, it said:
```checking for main in -lpgplot... no
configure: error: pgplot library not found

configure:3692: checking for main in -lpgplot
configure:3711: gcc -o conftest -g -O2   -L/usr/local/pgplot conftest.c -lpgplot  -lX11  >&5
/opt/pgplot/gcc-4.8/libpgplot.so: undefined reference to `_gfortran_st_close'
/opt/pgplot/gcc-4.8/libpgplot.so: undefined reference to `_gfortran_st_read_done'
/opt/pgplot/gcc-4.8/libpgplot.so: undefined reference to `_gfortran_transfer_integer'
```

So I updated the configure.ac to look for some common FCs, and try to automatically figure out the libraries to link.